### PR TITLE
updates monitoring

### DIFF
--- a/pkg/cache/cleanup.go
+++ b/pkg/cache/cleanup.go
@@ -3,6 +3,8 @@ package cache
 import (
 	"container/heap"
 	"time"
+
+	"github.com/lushenle/simple-cache/pkg/metrics"
 )
 
 func (c *Cache) cleanupWorker() {
@@ -46,6 +48,7 @@ func (c *Cache) cleanupExpired() {
 			if item.expiration.Equal(entry.expiration) {
 				c.delInternal(entry.key)
 			}
+			metrics.UpdateExpirationHeapSize(c.expirationHeap.Len())
 		}
 	}
 }

--- a/pkg/cache/del.go
+++ b/pkg/cache/del.go
@@ -34,10 +34,12 @@ func (c *Cache) delInternal(key string) {
 	for i, entry := range *c.expirationHeap {
 		if entry.key == key {
 			heap.Remove(c.expirationHeap, i)
+			metrics.UpdateExpirationHeapSize(c.expirationHeap.Len())
 			break
 		}
 	}
 
 	delete(c.items, key)
 	c.prefixTree.Delete(key)
+	metrics.UpdateKeysTotal(len(c.items))
 }

--- a/pkg/cache/reset.go
+++ b/pkg/cache/reset.go
@@ -1,5 +1,7 @@
 package cache
 
+import "github.com/lushenle/simple-cache/pkg/metrics"
+
 func (c *Cache) Reset() int {
 	c.logger.Info("resetting cache")
 
@@ -7,5 +9,7 @@ func (c *Cache) Reset() int {
 	defer c.mu.Unlock()
 	count := len(c.items)
 	c.items = make(map[string]*Item)
+	metrics.UpdateKeysTotal(0)
+	metrics.UpdateExpirationHeapSize(c.expirationHeap.Len())
 	return count
 }

--- a/pkg/cache/set.go
+++ b/pkg/cache/set.go
@@ -40,6 +40,7 @@ func (c *Cache) Set(key string, value any, expire string) error {
 			key:        key,
 			expiration: expiration,
 		})
+		metrics.UpdateExpirationHeapSize(c.expirationHeap.Len())
 	}
 
 	c.setInternal(key, &Item{
@@ -53,6 +54,7 @@ func (c *Cache) Set(key string, value any, expire string) error {
 	itemPool.Put(item)
 
 	c.updateSizeMetrics()
+	metrics.UpdateKeysTotal(len(c.items))
 
 	return nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -13,6 +13,38 @@ type InstrumentedRWMutex struct {
 }
 
 var (
+	// New metrics per docs/monitoring.md
+	RequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "simple_cache_requests_total",
+			Help: "Total number of cache requests",
+		},
+		[]string{"op", "status"},
+	)
+
+	RequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "simple_cache_request_duration_seconds",
+			Help:    "Latency of cache requests",
+			Buckets: prometheus.ExponentialBuckets(1e-5, 2, 15),
+		},
+		[]string{"op"},
+	)
+
+	KeysTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "simple_cache_keys_total",
+			Help: "Total number of keys in cache",
+		},
+	)
+
+	ExpirationHeapSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "simple_cache_expiration_heap_size",
+			Help: "Number of entries in expiration heap",
+		},
+	)
+
 	// OperationDuration latency metrics
 	OperationDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -56,15 +88,62 @@ var (
 		},
 		[]string{"op_type"}, // read/write
 	)
+
+	// Raft metrics
+	RaftRole = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "raft_role",
+			Help: "Current Raft role of node (label 'role' set to 1 for current role)",
+		},
+		[]string{"node_id", "role"},
+	)
+
+	RaftCommitIndex = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "raft_commit_index",
+			Help: "Current Raft commit index",
+		},
+	)
+
+	RaftLastApplied = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "raft_last_applied",
+			Help: "Last applied log index",
+		},
+	)
+
+	RaftLeaderChanges = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "raft_leader_changes_total",
+			Help: "Total leader role changes",
+		},
+	)
+
+	RaftAppendEntriesLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "raft_append_entries_latency_seconds",
+			Help:    "Latency of AppendEntries broadcast",
+			Buckets: prometheus.ExponentialBuckets(1e-4, 2, 15),
+		},
+	)
 )
 
 func Init() {
 	prometheus.MustRegister(
+		RequestsTotal,
+		RequestDuration,
+		KeysTotal,
+		ExpirationHeapSize,
 		OperationDuration,
 		OperationCount,
 		CacheSize,
 		MemoryUsage,
 		MutexWait,
+		RaftRole,
+		RaftCommitIndex,
+		RaftLastApplied,
+		RaftLeaderChanges,
+		RaftAppendEntriesLatency,
 	)
 
 	go updateMemoryUsage()
@@ -84,6 +163,7 @@ func updateMemoryUsage() {
 
 func ObserveOperation(duration time.Duration, opType string) {
 	OperationDuration.WithLabelValues(opType).Observe(duration.Seconds())
+	RequestDuration.WithLabelValues(opType).Observe(duration.Seconds())
 }
 
 func IncOperation(opType string, success bool) {
@@ -93,7 +173,27 @@ func IncOperation(opType string, success bool) {
 	}
 
 	OperationCount.WithLabelValues(opType, status).Inc()
+	RequestsTotal.WithLabelValues(opType, status).Inc()
 }
+
+func UpdateKeysTotal(n int) {
+	KeysTotal.Set(float64(n))
+}
+
+func UpdateExpirationHeapSize(n int) {
+	ExpirationHeapSize.Set(float64(n))
+}
+
+// Raft helpers
+func SetRaftRole(nodeID, role string) {
+	// Set 1 for current role; other role series are not touched here
+	RaftRole.WithLabelValues(nodeID, role).Set(1)
+}
+
+func SetRaftCommitIndex(v uint64)                 { RaftCommitIndex.Set(float64(v)) }
+func SetRaftLastApplied(v uint64)                 { RaftLastApplied.Set(float64(v)) }
+func IncRaftLeaderChanges()                       { RaftLeaderChanges.Inc() }
+func ObserveAppendEntriesLatency(d time.Duration) { RaftAppendEntriesLatency.Observe(d.Seconds()) }
 
 func (m *InstrumentedRWMutex) Lock(opType string) {
 	start := time.Now()

--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"sync/atomic"
 	"time"
+
+	"github.com/lushenle/simple-cache/pkg/metrics"
 )
 
 type Applier interface {
@@ -27,6 +29,7 @@ type Node struct {
 func NewNode(id string, addr string, peers []string, storage *Storage, applier Applier, heartbeat, election time.Duration) *Node {
 	n := &Node{id: id, storage: storage, applier: applier, hb: heartbeat, el: election}
 	n.role.Store(Leader)
+	metrics.SetRaftRole(n.id, string(Leader))
 	n.leaderID.Store("")
 	n.trans = NewHTTPTransport(addr, peers)
 	n.trans.Start(n)
@@ -41,8 +44,10 @@ func (n *Node) loop() {
 	defer ticker.Stop()
 	for range ticker.C {
 		if n.Role() == Leader {
+			start := time.Now()
 			req := AppendEntriesReq{Term: n.term, LeaderID: n.id, CommitIdx: n.commitIdx}
 			n.trans.broadcastAppend(req)
+			metrics.ObserveAppendEntriesLatency(time.Since(start))
 		}
 	}
 }
@@ -55,21 +60,31 @@ func (n *Node) Submit(cmd interface{}) (interface{}, error) {
 	if err := n.storage.Append(b); err != nil {
 		return nil, err
 	}
+	start := time.Now()
 	ack := n.trans.broadcastAppend(AppendEntriesReq{Term: n.term, LeaderID: n.id, Entries: [][]byte{b}, CommitIdx: n.commitIdx + 1})
+	metrics.ObserveAppendEntriesLatency(time.Since(start))
 	if ack < 1 {
 		return nil, ErrCommit{}
 	}
 	n.commitIdx++
+	metrics.SetRaftCommitIndex(n.commitIdx)
 	return n.applier.Apply(cmd)
 }
 
 func (n *Node) onAppendEntries(req AppendEntriesReq) AppendEntriesResp {
 	n.leaderID.Store(req.LeaderID)
+	prev := n.Role()
+	if prev != Follower {
+		metrics.IncRaftLeaderChanges()
+	}
 	n.role.Store(Follower)
+	metrics.SetRaftRole(n.id, string(Follower))
 	for _, e := range req.Entries {
 		_ = n.storage.Append(e)
 	}
 	n.commitIdx = req.CommitIdx
+	metrics.SetRaftCommitIndex(n.commitIdx)
+	metrics.SetRaftLastApplied(n.commitIdx)
 	return AppendEntriesResp{Term: n.term, Success: true}
 }
 


### PR DESCRIPTION
This pull request introduces a comprehensive set of metrics for both cache and Raft subsystems, integrating Prometheus-based instrumentation throughout the codebase. The changes enable detailed monitoring of cache operations and Raft consensus internals, including request rates, latencies, cache size, expiration heap size, and Raft role/commit metrics. These metrics are updated at key points in the cache lifecycle and Raft state transitions to provide real-time observability.

**Cache Metrics Integration**
* Added Prometheus gauges and counters for tracking the total number of cache keys (`KeysTotal`) and the size of the expiration heap (`ExpirationHeapSize`). These are updated in cache mutation operations such as set, delete, reset, and cleanup. [[1]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R16-R47) [[2]](diffhunk://#diff-75de36c6fb0ca495fa8f64cc48dfbb0e50e37fe82cbb6a330bce57a2659904b4R37-R44) [[3]](diffhunk://#diff-061c6c66f8a80a559c17006c035ebb9254de335c79b41071ea95c2317e3b6990R51) [[4]](diffhunk://#diff-ff04e29901e7b5b76004bbc81ec0efe0316c6e0125fbc2f1c70606a6551e1dceR43) [[5]](diffhunk://#diff-ff04e29901e7b5b76004bbc81ec0efe0316c6e0125fbc2f1c70606a6551e1dceR57) [[6]](diffhunk://#diff-f12e71c80b5f26dd73877dba09ef9788b7e874130b4869084cca2e7b69412868R3-R13)
* Introduced request counters (`RequestsTotal`) and latency histograms (`RequestDuration`) for cache operations, with updates at appropriate points in the code. [[1]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R16-R47) [[2]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R166) [[3]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R176-R197)

**Raft Metrics Integration**
* Implemented Prometheus metrics for Raft internals: role (`RaftRole`), commit index (`RaftCommitIndex`), last applied index (`RaftLastApplied`), leader changes (`RaftLeaderChanges`), and append entries latency (`RaftAppendEntriesLatency`). Metrics are updated during node initialization, role changes, commit/apply, and broadcast operations. [[1]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R91-R146) [[2]](diffhunk://#diff-b5671fb06d2875bdcd02f28b0e8b14f6747227c2564daf13491c40ab4dce7f38R32) [[3]](diffhunk://#diff-b5671fb06d2875bdcd02f28b0e8b14f6747227c2564daf13491c40ab4dce7f38R47-R50) [[4]](diffhunk://#diff-b5671fb06d2875bdcd02f28b0e8b14f6747227c2564daf13491c40ab4dce7f38R63-R87)

**Instrumentation and Helper Functions**
* Added helper functions in `pkg/metrics/metrics.go` to update and observe all new metrics, ensuring consistent and centralized metric management.

**Codebase Integration**
* Imported the new metrics package in all relevant files (`pkg/cache/cleanup.go`, `pkg/cache/del.go`, `pkg/cache/reset.go`, `pkg/raft/node.go`) and invoked metric update functions at logical points in the cache and Raft workflows. [[1]](diffhunk://#diff-061c6c66f8a80a559c17006c035ebb9254de335c79b41071ea95c2317e3b6990R6-R7) [[2]](diffhunk://#diff-b5671fb06d2875bdcd02f28b0e8b14f6747227c2564daf13491c40ab4dce7f38R7-R8) [[3]](diffhunk://#diff-f12e71c80b5f26dd73877dba09ef9788b7e874130b4869084cca2e7b69412868R3-R13)

These changes lay the foundation for robust monitoring and troubleshooting of the cache and distributed consensus system.