### PR TITLE
fix: correct Raft vote log comparison, preserve value types in persis…

### DIFF
--- a/pkg/cache/persistence.go
+++ b/pkg/cache/persistence.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"container/heap"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -18,8 +19,9 @@ import (
 )
 
 const (
-	dumpMagic   = "SCDF"
-	dumpVersion = 1
+	dumpMagic     = "SCDF"
+	dumpVersion   = 2
+	dumpVersionV1 = 1
 )
 
 // DumpEntry represents a single cache entry in the dump file.
@@ -85,7 +87,6 @@ func (c *Cache) Dump(nodeID, format, path string) (*DumpResult, error) {
 	}
 
 	data, entries, expiredCount, err := c.dumpToBytes(nodeID, format)
-
 	if err != nil {
 		metrics.IncPersistenceOp("dump", "error")
 		return nil, fmt.Errorf("serialize dump data: %w", err)
@@ -93,13 +94,13 @@ func (c *Cache) Dump(nodeID, format, path string) (*DumpResult, error) {
 
 	// Atomic and durable write: write+fsync temp file, rename, then fsync directory
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		metrics.IncPersistenceOp("dump", "error")
 		return nil, fmt.Errorf("create directory %s: %w", dir, err)
 	}
 
 	tmpPath := path + ".tmp"
-	tmpFile, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	tmpFile, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		metrics.IncPersistenceOp("dump", "error")
 		return nil, fmt.Errorf("create temp file: %w", err)
@@ -400,6 +401,11 @@ func encodeBinaryDump(entries []DumpEntry) ([]byte, error) {
 		} else {
 			buf = append(buf, 0)
 		}
+
+		// ValueType (v2+)
+		vtBytes := []byte(e.ValueType)
+		buf = binary.BigEndian.AppendUint32(buf, uint32(len(vtBytes)))
+		buf = append(buf, vtBytes...)
 	}
 
 	// Footer: CRC32
@@ -421,7 +427,7 @@ func decodeBinaryDump(data []byte) ([]DumpEntry, error) {
 	}
 
 	version := binary.BigEndian.Uint32(data[4:8])
-	if version != dumpVersion {
+	if version != dumpVersion && version != dumpVersionV1 {
 		return nil, fmt.Errorf("unsupported version: %d", version)
 	}
 
@@ -490,10 +496,25 @@ func decodeBinaryDump(data []byte) ([]DumpEntry, error) {
 		}
 		offset += 1
 
+		valueType := "string" // default for v1
+		if version >= dumpVersion {
+			// ValueType (v2+)
+			if offset+4 > footerStart {
+				return nil, fmt.Errorf("truncated dump at entry %d value type length", i)
+			}
+			vtLen := binary.BigEndian.Uint32(data[offset : offset+4])
+			offset += 4
+			if offset+int(vtLen) > footerStart {
+				return nil, fmt.Errorf("truncated dump at entry %d value type data", i)
+			}
+			valueType = string(data[offset : offset+int(vtLen)])
+			offset += int(vtLen)
+		}
+
 		entry := DumpEntry{
 			Key:           key,
 			Value:         value,
-			ValueType:     "string", // binary format doesn't preserve type info
+			ValueType:     valueType,
 			HasExpiration: hasExp,
 		}
 		if hasExp && expUnix != 0 {
@@ -522,7 +543,7 @@ func serializeValue(v any) (string, string) {
 	case string:
 		return val, "string"
 	case []byte:
-		return string(val), "bytes" // Note: lossy for non-UTF-8 bytes
+		return base64.StdEncoding.EncodeToString(val), "bytes"
 	default:
 		// Try JSON marshal for complex types
 		b, err := json.Marshal(val)
@@ -535,10 +556,20 @@ func serializeValue(v any) (string, string) {
 
 func deserializeValue(data, valueType string) any {
 	switch valueType {
+	case "nil":
+		return nil
 	case "bytes":
-		return []byte(data)
-	case "json", "other":
-		return data // Return as string
+		decoded, err := base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			return []byte(data)
+		}
+		return decoded
+	case "json":
+		var v any
+		if err := json.Unmarshal([]byte(data), &v); err != nil {
+			return data
+		}
+		return v
 	default:
 		return data
 	}

--- a/pkg/cache/persistence_test.go
+++ b/pkg/cache/persistence_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -21,7 +22,7 @@ func TestDumpAndLoadBinary(t *testing.T) {
 
 	// Set some data
 	require.NoError(t, c.Set("key1", "value1", "1h"))
-	require.NoError(t, c.Set("key2", "value2", "")) // no expiration
+	require.NoError(t, c.Set("key2", "value2", ""))    // no expiration
 	require.NoError(t, c.Set("key3", "value3", "1ns")) // already expired
 
 	tmpDir := t.TempDir()
@@ -80,7 +81,7 @@ func TestDumpAndLoadJSON(t *testing.T) {
 	// Verify JSON is valid and readable
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
-	assert.Contains(t, string(data), `"version": 1`)
+	assert.Contains(t, string(data), `"version": 2`)
 	assert.Contains(t, string(data), `"node_id": "node1"`)
 	assert.Contains(t, string(data), `"key1"`)
 	assert.Contains(t, string(data), `"key2"`)
@@ -116,7 +117,7 @@ func TestLoadExpiredKeys(t *testing.T) {
   ]
 }`, time.Now().UTC().Format(time.RFC3339Nano), futureTime, pastTime)
 
-	require.NoError(t, os.WriteFile(path, []byte(dumpData), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(dumpData), 0o644))
 
 	// Load - key2 should be skipped (expired), key1 should be loaded
 	c := New(time.Minute, logger)
@@ -164,7 +165,7 @@ func TestLoadAutoDetect(t *testing.T) {
 	// Dump binary to the auto-detect location: {tmpDir}/data/cache-node1.dump
 	dataDir := filepath.Join(tmpDir, "data")
 	binPath := filepath.Join(dataDir, "cache-node1.dump")
-	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
 
 	_, err := c.Dump("node1", "binary", binPath)
 	require.NoError(t, err)
@@ -253,4 +254,105 @@ func TestDecodeBinaryDumpRejectsTruncatedEntryByCount(t *testing.T) {
 	_, err = decodeBinaryDump(data)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "truncated dump")
+}
+
+func TestSerializeDeserializeTypedValues(t *testing.T) {
+	// nil
+	s, vt := serializeValue(nil)
+	assert.Equal(t, "", s)
+	assert.Equal(t, "nil", vt)
+	assert.Nil(t, deserializeValue(s, vt))
+
+	// string
+	s, vt = serializeValue("hello")
+	assert.Equal(t, "hello", s)
+	assert.Equal(t, "string", vt)
+	assert.Equal(t, "hello", deserializeValue(s, vt))
+
+	// []byte
+	origBytes := []byte{0xFF, 0x00, 0xAB}
+	s, vt = serializeValue(origBytes)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(origBytes), s)
+	assert.Equal(t, "bytes", vt)
+	restored := deserializeValue(s, vt)
+	assert.Equal(t, origBytes, restored)
+
+	// map (json)
+	m := map[string]int{"a": 1}
+	s, vt = serializeValue(m)
+	assert.Equal(t, "json", vt)
+	restoredVal := deserializeValue(s, vt)
+	restoredMap, ok := restoredVal.(map[string]interface{})
+	require.True(t, ok, "expected map[string]interface{}, got %T", restoredVal)
+	assert.Equal(t, float64(1), restoredMap["a"])
+}
+
+func TestDumpAndLoadBinaryWithValueType(t *testing.T) {
+	entries := []DumpEntry{
+		{Key: "str", Value: "hello", ValueType: "string"},
+		{Key: "bin", Value: base64.StdEncoding.EncodeToString([]byte{0xDE, 0xAD}), ValueType: "bytes"},
+		{Key: "obj", Value: `{"x":1}`, ValueType: "json"},
+		{Key: "nul", Value: "", ValueType: "nil"},
+	}
+
+	data, err := encodeBinaryDump(entries)
+	require.NoError(t, err)
+
+	decoded, err := decodeBinaryDump(data)
+	require.NoError(t, err)
+	require.Len(t, decoded, len(entries))
+
+	for i, e := range entries {
+		assert.Equal(t, e.Key, decoded[i].Key, "key mismatch at %d", i)
+		assert.Equal(t, e.Value, decoded[i].Value, "value mismatch at %d", i)
+		assert.Equal(t, e.ValueType, decoded[i].ValueType, "value_type mismatch at %d", i)
+	}
+}
+
+func TestDecodeBinaryDumpV1Compatibility(t *testing.T) {
+	// Manually construct a v1 binary dump (without ValueType field per entry).
+	// Layout: magic(4) + version(4) + count(4) + flags(4)
+	//         per entry: keyLen(4) + key + valLen(4) + val + expUnix(8) + hasExp(1)
+	//         footer: crc32(4) + padding(4)
+	type v1Entry struct {
+		key   string
+		value string
+	}
+	v1Entries := []v1Entry{
+		{"k1", "v1"},
+		{"k2", "v2"},
+	}
+
+	buf := make([]byte, 0, 256)
+	buf = append(buf, []byte("SCDF")...)                             // magic
+	buf = binary.BigEndian.AppendUint32(buf, 1)                      // version = 1
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(v1Entries))) // count
+	buf = binary.BigEndian.AppendUint32(buf, 0)                      // flags
+
+	for _, e := range v1Entries {
+		kb := []byte(e.key)
+		buf = binary.BigEndian.AppendUint32(buf, uint32(len(kb)))
+		buf = append(buf, kb...)
+		vb := []byte(e.value)
+		buf = binary.BigEndian.AppendUint32(buf, uint32(len(vb)))
+		buf = append(buf, vb...)
+		buf = binary.BigEndian.AppendUint64(buf, 0) // no expiration
+		buf = append(buf, 0)                        // hasExp = false
+	}
+
+	// Footer
+	checksum := crc32.ChecksumIEEE(buf)
+	buf = binary.BigEndian.AppendUint32(buf, checksum)
+	buf = binary.BigEndian.AppendUint32(buf, 0) // padding
+
+	decoded, err := decodeBinaryDump(buf)
+	require.NoError(t, err)
+	require.Len(t, decoded, 2)
+
+	for i, e := range v1Entries {
+		assert.Equal(t, e.key, decoded[i].Key)
+		assert.Equal(t, e.value, decoded[i].Value)
+		assert.Equal(t, "string", decoded[i].ValueType, "v1 entries should default to string type")
+		assert.False(t, decoded[i].HasExpiration)
+	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,8 +9,10 @@ import (
 )
 
 // stopCh is used to gracefully stop the memory usage goroutine.
-var stopCh chan struct{}
-var initOnce sync.Once
+var (
+	stopCh   chan struct{}
+	initOnce sync.Once
+)
 
 type InstrumentedRWMutex struct {
 	mu sync.RWMutex
@@ -288,10 +290,15 @@ func ObserveAppendEntriesLatency(d time.Duration) { RaftAppendEntriesLatency.Obs
 func SetPeersTotal(n int)                         { PeersTotal.Set(float64(n)) }
 
 // Persistence metrics helpers
-func IncPersistenceOp(op, status string)            { PersistenceOpTotal.WithLabelValues(op, status).Inc() }
-func ObservePersistenceDuration(op string, d float64) { PersistenceDuration.WithLabelValues(op).Observe(d) }
-func SetDumpKeys(n int64)                           { DumpKeysGauge.Set(float64(n)) }
-func SetLoadKeys(loaded, skipped int64)             { LoadKeysGauge.WithLabelValues("loaded").Set(float64(loaded)); LoadKeysGauge.WithLabelValues("skipped").Set(float64(skipped)) }
+func IncPersistenceOp(op, status string) { PersistenceOpTotal.WithLabelValues(op, status).Inc() }
+func ObservePersistenceDuration(op string, d float64) {
+	PersistenceDuration.WithLabelValues(op).Observe(d)
+}
+func SetDumpKeys(n int64) { DumpKeysGauge.Set(float64(n)) }
+func SetLoadKeys(loaded, skipped int64) {
+	LoadKeysGauge.WithLabelValues("loaded").Set(float64(loaded))
+	LoadKeysGauge.WithLabelValues("skipped").Set(float64(skipped))
+}
 
 func (m *InstrumentedRWMutex) Lock(opType LockOp) {
 	start := time.Now()

--- a/pkg/raft/http_transport.go
+++ b/pkg/raft/http_transport.go
@@ -57,8 +57,15 @@ func (t *HTTPTransport) Start(node *Node) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/raft/append", func(w http.ResponseWriter, r *http.Request) {
 		var req AppendEntriesReq
-		b, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(b, &req)
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body failed", http.StatusBadRequest)
+			return
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
 		if node.logger != nil {
 			node.logger.Debug("http recv append", zap.String("node", node.id), zap.String("leader", req.LeaderID), zap.Uint64("term", req.Term))
 		}
@@ -69,8 +76,15 @@ func (t *HTTPTransport) Start(node *Node) {
 	})
 	mux.HandleFunc("/raft/vote", func(w http.ResponseWriter, r *http.Request) {
 		var req RequestVoteReq
-		b, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(b, &req)
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body failed", http.StatusBadRequest)
+			return
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
 		if node.logger != nil {
 			node.logger.Debug("http recv vote", zap.String("node", node.id), zap.String("candidate", req.CandidateID), zap.Uint64("term", req.Term))
 		}
@@ -81,8 +95,15 @@ func (t *HTTPTransport) Start(node *Node) {
 	})
 	mux.HandleFunc("/raft/install_snapshot", func(w http.ResponseWriter, r *http.Request) {
 		var req InstallSnapshotReq
-		b, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(b, &req)
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body failed", http.StatusBadRequest)
+			return
+		}
+		if err := json.Unmarshal(b, &req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
 		if node.logger != nil {
 			node.logger.Debug("http recv install snapshot", zap.String("node", node.id), zap.String("leader", req.LeaderID), zap.Uint64("term", req.Term), zap.Uint64("index", req.LastIncludedIndex))
 		}

--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -536,10 +536,11 @@ func (n *Node) onRequestVote(req RequestVoteReq) RequestVoteResp {
 	if req.Term > n.term {
 		n.stepDownLocked(req.Term)
 	}
-	if req.LastLogIndex < n.lastLogIndex {
+	// Raft §5.4.1: compare last log term first, then index
+	if req.LastLogTerm < n.lastLogTerm {
 		return RequestVoteResp{Term: n.term, VoteGranted: false}
 	}
-	if req.LastLogIndex == n.lastLogIndex && req.LastLogTerm < n.lastLogTerm {
+	if req.LastLogTerm == n.lastLogTerm && req.LastLogIndex < n.lastLogIndex {
 		return RequestVoteResp{Term: n.term, VoteGranted: false}
 	}
 	if n.votedFor == "" || n.votedFor == req.CandidateID {

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -331,3 +331,87 @@ func contains(items []string, target string) bool {
 	}
 	return false
 }
+
+func TestRequestVoteLogComparison(t *testing.T) {
+	logger := zap.NewNop()
+	baseDir := t.TempDir()
+	addr := freeAddr(t)
+	peers := []string{"http://" + addr}
+
+	applier := newFakeApplier()
+	node, err := NewNode("node-1", addr, peers, NewStorage(filepath.Join(baseDir, "node.wal")), applier, 80*time.Millisecond, 180*time.Millisecond, true, 8, logger)
+	require.NoError(t, err)
+	defer node.Close()
+
+	waitForLeader(t, node)
+
+	// Submit a few entries so the node has some log state.
+	_, err = node.Submit(&command.SetCommand{Key: "a", Value: "1"})
+	require.NoError(t, err)
+	_, err = node.Submit(&command.SetCommand{Key: "b", Value: "2"})
+	require.NoError(t, err)
+	waitForCondition(t, func() bool { return applier.Has("a") && applier.Has("b") })
+
+	cases := []struct {
+		name        string
+		buildReq    func() RequestVoteReq
+		wantGranted bool
+	}{
+		{
+			name: "candidate with higher term but shorter log",
+			buildReq: func() RequestVoteReq {
+				return RequestVoteReq{
+					Term:         node.term + 1,
+					CandidateID:  "candidate-1",
+					LastLogTerm:  node.lastLogTerm + 1,
+					LastLogIndex: node.lastLogIndex - 1,
+				}
+			},
+			wantGranted: true,
+		},
+		{
+			name: "candidate with lower term",
+			buildReq: func() RequestVoteReq {
+				return RequestVoteReq{
+					Term:         node.term + 1,
+					CandidateID:  "candidate-2",
+					LastLogTerm:  node.lastLogTerm - 1,
+					LastLogIndex: node.lastLogIndex + 10,
+				}
+			},
+			wantGranted: false,
+		},
+		{
+			name: "candidate with same term but shorter log",
+			buildReq: func() RequestVoteReq {
+				return RequestVoteReq{
+					Term:         node.term + 1,
+					CandidateID:  "candidate-3",
+					LastLogTerm:  node.lastLogTerm,
+					LastLogIndex: node.lastLogIndex - 1,
+				}
+			},
+			wantGranted: false,
+		},
+		{
+			name: "candidate with same term and longer log",
+			buildReq: func() RequestVoteReq {
+				return RequestVoteReq{
+					Term:         node.term + 1,
+					CandidateID:  "candidate-4",
+					LastLogTerm:  node.lastLogTerm,
+					LastLogIndex: node.lastLogIndex + 1,
+				}
+			},
+			wantGranted: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := tc.buildReq()
+			resp := node.onRequestVote(req)
+			require.Equal(t, tc.wantGranted, resp.VoteGranted)
+		})
+	}
+}

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -192,7 +192,7 @@ func (s *Storage) LoadMeta() (*Meta, error) {
 	var m Meta
 	dec := json.NewDecoder(f)
 	if err := dec.Decode(&m); err != nil {
-		return &Meta{}, nil
+		return nil, fmt.Errorf("corrupt raft meta file %s: %w", mp, err)
 	}
 	return &m, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -197,6 +197,10 @@ func (s *CacheService) Reset(ctx context.Context, req *pb.ResetRequest) (*pb.Res
 }
 
 func (s *CacheService) Search(ctx context.Context, req *pb.SearchRequest) (*pb.SearchResponse, error) {
+	if s.node != nil && s.node.Role() != raft.Leader {
+		return nil, status.Error(codes.FailedPrecondition, "not leader")
+	}
+
 	pattern := req.Pattern
 	useRegex := strings.HasPrefix(pattern, "regex:")
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -118,3 +118,36 @@ func TestGRPCServer(t *testing.T) {
 		assert.Equal(t, common.ProbeStateNotReady, ready.Status)
 	})
 }
+
+func TestSearchRejectsNonLeader(t *testing.T) {
+	plugin := log.NewStdoutPlugin(zapcore.DebugLevel)
+	logger := log.NewLogger(plugin)
+
+	c := cache.New(time.Second*3, logger)
+	srv := New(c, "test-node")
+
+	transportAddr := "127.0.0.1:0"
+	node, err := raft.NewNode(
+		"test-node-search",
+		transportAddr,
+		[]string{"http://" + transportAddr, "http://127.0.0.1:19999"},
+		raft.NewStorage(filepath.Join(t.TempDir(), "raft-search.wal")),
+		srv,
+		50*time.Millisecond,
+		500*time.Millisecond,
+		true,
+		8,
+		logger,
+	)
+	require.NoError(t, err)
+	defer node.Close()
+	srv.UseRaft(node)
+
+	_, err = srv.Search(context.Background(), &pb.SearchRequest{
+		Pattern: "test:*",
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}


### PR DESCRIPTION
…tence, and harden distributed consistency

- Fix RequestVote to compare last log term before index per Raft §5.4.1
- Fail fast on corrupt raft meta instead of silently resetting state
- Add leader check to Search for consistent read semantics
- Validate request body in raft HTTP handlers
- Upgrade binary dump to v2 with ValueType field and base64 bytes encoding
- Add tests for typed value persistence, vote log comparison, and follower Search rejection