### PR TITLE
docs: sync all docs to match current code implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@
 - **优雅关闭** — 完整的 8 步优雅关闭流程（gRPC → Gateway → Raft → Dump → Cache → Config → Metrics → Logger）
 - **数据持久化** — 支持将缓存数据 Dump 到本地磁盘（二进制/JSON 双格式）；single 模式支持自动/手动 Load 恢复，distributed 模式依赖 WAL replay
 - **客户端 SDK** — 封装完整的 gRPC 客户端，提供友好的 Go API（包括批量操作）
+- **自动 Leader 切主** — Cluster 模式 client 自动发现 Leader，遇到 `not leader` 错误自动重试并切主
+- **gRPC Name Resolver** — 内置 `simplecache://` URI scheme resolver，与 gRPC 框架原生集成
 
 ---
 
@@ -431,7 +433,8 @@ simple-cache/
 │   │   ├── metrics.go           #   缓存大小估算
 │   │   └── *_test.go            #   单元测试 + 基准测试
 │   ├── client/                  # 📦 gRPC 客户端 SDK
-│   │   └── client.go            #   Get/Set/Del/Search/BatchSet/ExpireKey/Reset
+│   │   ├── client.go            #   Get/Set/Del/Search/BatchSet/ExpireKey/Reset
+│   └── resolver/            #   自定义 gRPC Name Resolver (simplecache://)
 │   ├── cmd/                     # 📦 主程序入口
 │   │   ├── main.go              #   启动流程 + 优雅关闭 + HTTP 端点
 │   │   └── swagger/             #   内嵌 Swagger UI 静态文件
@@ -663,13 +666,46 @@ existed, err := cli.ExpireKey(ctx, "greeting", 5*time.Second)
 existed, err := cli.ExpireKey(ctx, "greeting", 0)
 ```
 
+### 集群模式（自动切主）
+
+```go
+// 使用 NewCluster 创建自动切主客户端
+cli, err := client.NewCluster(ctx, []client.NodeSpec{
+    {ID: "n1", GRPCAddr: ":5051", RaftAddr: "http://:9090"},
+    {ID: "n2", GRPCAddr: ":5052", RaftAddr: "http://:9091"},
+    {ID: "n3", GRPCAddr: ":5053", RaftAddr: "http://:9092"},
+}, client.WithCheckInterval(10*time.Second))
+if err != nil {
+    panic(err)
+}
+defer cli.Close()
+
+// 自动重试与切主：写操作
+err = cli.Set(ctx, "key", "value", 0)  // 连接到 Leader，失败时自动切到新 Leader
+
+// 自动重试与切主：读操作
+val, found, err := cli.Get(ctx, "key")
+```
+
+### 使用 gRPC Name Resolver（Phase 3）
+
+```go
+import "github.com/lushenle/simple-cache/pkg/client/resolver"
+
+conn, err := grpc.NewClient("simplecache:///:5051,:5052,:5053",
+    grpc.WithResolvers(&resolver.Builder{}),
+    grpc.WithTransportCredentials(insecure.NewCredentials()),
+)
+```
+
 ### 完整方法列表
 
 | 方法 | 签名 | 说明 |
 |------|------|------|
-| `New` | `New(ctx, addr, ...opts) (*Client, error)` | 创建客户端（带连接就绪检查） |
-| `NewDefault` | `NewDefault(addr, ...opts) (*Client, error)` | 使用 `context.Background()` 创建 |
+| `New` | `New(ctx, addr, ...opts) (*Client, error)` | 创建单节点客户端（向后兼容） |
+| `NewDefault` | `NewDefault(addr, ...opts) (*Client, error)` | 使用 `context.Background()` 创建单节点客户端 |
 | `NewSecure` | `NewSecure(ctx, addr, certFile, ...opts) (*Client, error)` | 使用 TLS 证书创建安全连接 |
+| `NewCluster` | `NewCluster(ctx, nodes, ...opts) (*Client, error)` | 创建集群客户端（自动 Leader 发现/切主/重试） |
 | `Close` | `Close() error` | 关闭连接 |
 | `Get` | `Get(ctx, key) (value, found, error)` | 获取值 |
 | `Set` | `Set(ctx, key, value, ttl) error` | 设置值 |
@@ -694,6 +730,7 @@ existed, err := cli.ExpireKey(ctx, "greeting", 0)
 | `raft_http_addr` | string | `:9090` | Raft 节点间通信地址 |
 | `metrics_addr` | string | `:2112` | Prometheus 指标暴露地址 |
 | `peers` | []string | `[]` | 集群节点 Raft HTTP 地址列表 |
+| `peer_addresses` | map[string]string | `{}` | 节点 ID → gRPC 地址映射（Phase 2 leader 发现） |
 | `heartbeat_ms` | int | `200` | Leader 心跳间隔（毫秒） |
 | `election_ms` | int | `1200` | 选举超时基准值（毫秒），实际超时 = `election_ms + random(0..election_ms)` |
 | `hot_reload` | bool | `false` | 是否启用配置文件热重载（每秒轮询） |
@@ -741,7 +778,8 @@ graph LR
 1. **每个节点需要独立的端口** — gRPC、HTTP、Raft、Metrics 各自使用不同端口
 2. **所有节点的 `peers` 列表必须一致** — 包含集群中所有节点的 Raft HTTP 地址
 3. **建议至少 3 个节点** — Raft 需要多数派确认，2 个节点无法容忍任何故障
-4. **客户端可连接任意节点** — 当前分布式读写都应命中 Leader；Follower 默认返回 `FailedPrecondition`
+4. **客户端推荐使用 `NewCluster` 自动切主** — 多节点 client 自动发现 Leader，遇到 `not leader` 错误自动重试并切到新 Leader
+5. **Single-node client 仍可连接任意节点** — 但分布式写需命中 Leader，Follower 返回 `FailedPrecondition`
 
 ### 动态扩缩容
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,6 +49,7 @@ flowchart LR
 - 服务层 `pkg/server/server.go` 将请求转为 `command.*` 并通过 `pkg/fsm` 应用到 `pkg/cache`
 - 分布式模式下，写操作通过 `pkg/raft` 实现共识、WAL 持久化、snapshot/compaction，再应用到 FSM
 - 分布式读当前采用 Leader 线性一致读，Follower 直接返回 `FailedPrecondition`
+- 集群模式下 Client SDK (`NewCluster`) 自动发现 Leader、自动重试/切主
 - 缓存层使用 HashMap + Radix Tree + Min-Heap/ExpirationIndex 维护读写、搜索与 TTL
 - `pkg/cache/persistence.go` 的 Dump/Load 主要用于 single 模式缓存持久化；distributed 模式恢复依赖 Raft snapshot + WAL replay
 - 配置管理 `pkg/config/config.go` 支持 YAML 加载、原子配置与有限热重载
@@ -103,7 +104,7 @@ sequenceDiagram
 - 共识层：`pkg/raft` (Raft 选举、日志复制、snapshot/compaction、InstallSnapshot，含 `peer.go` 地址规范化)
 - 缓存引擎：`pkg/cache` (CRUD、TTL 过期、前缀/正则搜索、single 模式 Dump/Load 持久化)
 - 基础设施层：`pkg/config` (配置管理)、`pkg/log` (日志)、`pkg/metrics` (指标)、`pkg/utils` (工具)
-- 客户端：`pkg/client` (gRPC 客户端 SDK)
+- 客户端：`pkg/client` (gRPC 客户端 SDK，含自动 Leader 切主)、`pkg/client/resolver` (gRPC Name Resolver)
 
 ## 现状评估
 - 读写分离通过 `InstrumentedRWMutex` 与过期清理协程实现

--- a/docs/cache-persistence.md
+++ b/docs/cache-persistence.md
@@ -81,7 +81,7 @@ data/cache-{node_id}.dump.tmp    # 写入中的临时文件
 │              File Header (16 bytes)       │
 ├──────────────────────────────────────────┤
 │ Magic    [4 bytes] "SCDF"                │  文件魔数
-│ Version  [4 bytes] uint32 = 1            │  格式版本
+│ Version  [4 bytes] uint32 = 2            │  (v1 backward compat)  格式版本
 │ Count    [4 bytes] uint32                │  key-value 条目数
 │ Flags    [4 bytes] uint32                │  保留标志位
 ├──────────────────────────────────────────┤
@@ -93,6 +93,8 @@ data/cache-{node_id}.dump.tmp    # 写入中的临时文件
 │ Value    [ValLen bytes]                  │  value 数据
 │ ExpUnix  [8 bytes] int64                 │  过期时间 Unix 纳秒 (0=永不过期)
 │ HasExp   [1 byte]  bool                  │  是否有过期时间
+│ VTLen    [4 bytes] uint32                │  value_type 长度 (v2+)
+│ ValueType [VTLen bytes]                  │  序列化类型名称 (v2+)
 ├──────────────────────────────────────────┤
 │           ... more entries ...            │
 ├──────────────────────────────────────────┤
@@ -107,7 +109,7 @@ data/cache-{node_id}.dump.tmp    # 写入中的临时文件
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "node_id": "node-1",
   "dumped_at": "2026-04-09T10:30:00Z",
   "total_keys": 1000,
@@ -153,7 +155,7 @@ data/cache-{node_id}.dump.tmp    # 写入中的临时文件
 | 原始类型                    | 序列化方式             | value_type | 反序列化后类型                        |
 | --------------------------- | ---------------------- | ---------- | ------------------------------------- |
 | `string`                    | 直接存储               | `"string"` | `string`                              |
-| `[]byte`                    | `string(val)` 直接转换 | `"bytes"`  | `[]byte`（注意：非 UTF-8 字节会丢失） |
+| `[]byte`                    | base64.StdEncoding | `"bytes"`  | `[]byte`（base64 编码，支持任意字节，v2 特性） |
 | `json.Marshal` 可处理的类型 | JSON 编码              | `"json"`   | `string`（JSON 字符串）               |
 | 其他类型                    | `fmt.Sprintf("%v", v)` | `"other"`  | `string`                              |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,6 +13,7 @@
 | `raft_http_addr` | string | `:9090` | Raft 传输地址 |
 | `metrics_addr` | string | `:2112` | Prometheus 指标地址 |
 | `peers` | []string | `[]` | 同集群节点 Raft HTTP 地址列表 |
+| `peer_addresses` | map[string]string | `{}` | 节点 ID → gRPC 地址映射（Leader 快速发现） |
 | `heartbeat_ms` | int | `200` | Leader 心跳间隔（毫秒） |
 | `election_ms` | int | `1200` | 选举超时基准值（毫秒） |
 | `hot_reload` | bool | `false` | 是否开启配置文件热加载 |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -11,7 +11,7 @@
   - snapshot / log compaction
   - `InstallSnapshot` 追平落后 follower
 
-> 当前 distributed 模式下，读写请求都应命中 Leader。Follower 默认不对业务流量返回 ready。
+> 当前 distributed 模式下，读写请求都应命中 Leader。Follower 默认不对业务流量返回 ready。推荐使用 `NewCluster` 客户端（自动发现 Leader、自动切主）。
 
 ## 2. 关键事实
 
@@ -289,6 +289,8 @@ curl http://<node-metrics>/metrics | grep -E 'raft_commit_index|raft_last_applie
 3. 找到返回 `200` 的新 Leader
 4. 业务流量切到新 Leader
 5. 原 Leader 恢复后会以 follower 身份重新加入
+
+> 如果使用了 `NewCluster` 客户端，步骤 2-4 由客户端自动完成（后台健康检查 + 自动切主），无需人工干预。
 
 建议操作：
 


### PR DESCRIPTION
README.md:
- add auto leader failover and gRPC name resolver features
- add pkg/client/resolver/ to project structure
- add NewCluster, NodeSpec, cluster mode examples to client SDK
- add peer_addresses to config table
- recommend NewCluster for distributed deployment

docs/architecture.md:
- add NewCluster auto-failover description
- update module boundaries with resolver package

docs/deployment.md:
- add peer_addresses to config table

docs/runbook.md:
- mention NewCluster auto-failover in leader recovery section

docs/cache-persistence.md:
- bump binary format version v1 -> v2 (+ValueType field)
- add ValueType field to binary layout table
- bump JSON version field v1 -> v2
- []byte serialization: string(val) -> base64